### PR TITLE
Update genjavadoc compiler plugin version and make it configurable

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,9 +6,7 @@ organization := "com.eed3si9n"
 
 version := "0.3.0"
 
-sbtVersion in Global := "0.13.0" 
-
-scalaVersion in Global := "2.10.2" 
+scalaVersion in Global := "2.10.2"
 
 // CrossBuilding.crossSbtVersions := Seq("0.11.3", "0.11.2" ,"0.12")
 


### PR DESCRIPTION
genjavadoc compiler plugin version 0.7 was recently released with a resource leak fix. I have bumped the version in this plugin and also made that version configurable, so that this plugin would not need to be released whenever genjavadoc is updated.
