### PR TITLE
Update genjavadoc to 0.8

### DIFF
--- a/src/main/scala/sbtunidoc/Plugin.scala
+++ b/src/main/scala/sbtunidoc/Plugin.scala
@@ -42,7 +42,7 @@ object Plugin extends sbt.Plugin {
     // },
     // excludedProjects in unidoc := Seq(),
     unidocConfigurationFilter in unidoc := inConfigurations(sc),
-    unidocGenjavadocVersion in Global := "0.7"
+    unidocGenjavadocVersion in Global := "0.8"
   )
   def baseScalaUnidocTasks(sc: Configuration): Seq[sbt.Def.Setting[_]] = baseCommonUnidocTasks(sc) ++ Seq(
     target in unidoc := crossTarget.value / "unidoc",


### PR DESCRIPTION
This is needed as 0.8 includes fixes which make to possible to generate docs for more complicated cases (akka-http-core).

For the time being we'll just set this variable in our build, but good to keep this one up to date as well right away :) Thanks @2m for making it configurable!