### PR TITLE
Cross-build for SBT 1.0.0-RC3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,7 @@ lazy val root = (project in file(".")).
   settings(commonSettings: _*).
   settings(
     sbtPlugin := true,
+    crossSbtVersions := Vector("0.13.16", "1.0.0-RC3"),
     name := "sbt-unidoc",
     description := "sbt plugin to create a unified API document across projects",
     licenses := Seq("Apache License v2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html")),

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.16

--- a/src/main/scala-sbt-0.13/sbtunidoc/Unidoc.scala
+++ b/src/main/scala-sbt-0.13/sbtunidoc/Unidoc.scala
@@ -2,6 +2,7 @@ package sbtunidoc
 
 import sbt._
 import sbt.Keys._
+import xsbti.Reporter
 
 object Unidoc {
   import java.io.PrintWriter
@@ -9,7 +10,7 @@ object Unidoc {
   // This is straight out of docTaskSettings in Defaults.scala.
   def apply(cache: File, cs: Compiler.Compilers, srcs: Seq[File], cp: Classpath,
             sOpts: Seq[String], jOpts: Seq[String], xapis: Map[File, URL], maxErrors: Int,
-            out: File, config: Configuration, s: TaskStreams): File = {
+            out: File, config: Configuration, s: TaskStreams, spm: Seq[xsbti.Position => Option[xsbti.Position]]): File = {
     val hasScala = srcs.exists(_.name.endsWith(".scala"))
     val hasJava = srcs.exists(_.name.endsWith(".java"))
     val label = nameForSrc(config.name)
@@ -25,6 +26,7 @@ object Unidoc {
     runDoc(srcs, cp map {_.data}, out, options, maxErrors, s.log)
     out
   }
+
   private[this] def exported(w: PrintWriter, command: String): Seq[String] => Unit = args =>
     w.println( (command +: args).mkString(" ") )
   private[this] def exported(s: TaskStreams, command: String): Seq[String] => Unit = args =>

--- a/src/main/scala-sbt-1.0/sbtunidoc/Unidoc.scala
+++ b/src/main/scala-sbt-1.0/sbtunidoc/Unidoc.scala
@@ -1,0 +1,62 @@
+package sbtunidoc
+
+import sbt._
+import sbt.Keys._
+import sbt.internal.inc.{ AnalyzingCompiler, ManagedLoggedReporter }
+import sbt.internal.util.Attributed.data
+import xsbti.compile.{ Compilers, IncToolOptionsUtil }
+import xsbti.Reporter
+
+object Unidoc {
+  import java.io.PrintWriter
+
+  // This is straight out of docTaskSettings in Defaults.scala.
+  def apply(cache: File, cs: Compilers, srcs: Seq[File], cp: Classpath,
+            sOpts: Seq[String], jOpts: Seq[String], xapis: Map[File, URL], maxErrors: Int,
+            out: File, config: Configuration, s: TaskStreams, spm: Seq[xsbti.Position => Option[xsbti.Position]]): File = {
+    val hasScala = srcs.exists(_.name.endsWith(".scala"))
+    val hasJava = srcs.exists(_.name.endsWith(".java"))
+    val label = nameForSrc(config.name)
+    val reporter = new ManagedLoggedReporter(
+      maxErrors,
+      s.log,
+      foldMappers(spm))
+    (hasScala, hasJava) match {
+      case (true, _) =>
+        val options = sOpts ++ Opts.doc.externalAPI(xapis)
+        val runDoc = Doc.scaladoc(label, s.cacheStoreFactory sub "scala", cs.scalac match {
+          case ac: AnalyzingCompiler => ac.onArgs(exported(s, "scaladoc"))
+        }, Nil)
+        runDoc(srcs, data(cp).toList, out, options, maxErrors, s.log)
+      case (_, true) =>
+        val javadoc =
+          sbt.inc.Doc.cachedJavadoc(label, s.cacheStoreFactory sub "java", cs.javaTools)
+        javadoc.run(srcs.toList,
+          data(cp).toList,
+          out,
+          jOpts.toList,
+          IncToolOptionsUtil.defaultIncToolOptions(),
+          s.log,
+          reporter)
+      case _ => () // do nothing
+    }
+    out
+  }
+
+  private[this] def exported(w: PrintWriter, command: String): Seq[String] => Unit = args =>
+    w.println( (command +: args).mkString(" ") )
+  private[this] def exported(s: TaskStreams, command: String): Seq[String] => Unit = args =>
+    exported(s.text("export"), command)
+  private[this] def foldMappers[A](mappers: Seq[A => Option[A]]) =
+    mappers.foldRight({ p: A =>
+      p
+    }) { (mapper, mappers) =>
+      { p: A =>
+        mapper(p).getOrElse(mappers(p))
+      }
+    }
+  def nameForSrc(name: String): String = name match {
+    case "compile"|"javaunidoc"|"scalaunidoc" => "main"
+    case _ => name
+  }
+}

--- a/src/main/scala/sbtunidoc/BaseUnidocPlugin.scala
+++ b/src/main/scala/sbtunidoc/BaseUnidocPlugin.scala
@@ -22,7 +22,7 @@ object BaseUnidocPlugin extends AutoPlugin {
   def baseUnidocSettings(sc: Configuration): Seq[sbt.Def.Setting[_]] = Seq(
     doc := Unidoc(streams.value.cacheDirectory, (compilers in unidoc).value, (sources in unidoc).value, (fullClasspath in unidoc).value,
       (scalacOptions in unidoc).value, (javacOptions in unidoc).value, (apiMappings in unidoc).value, (maxErrors in unidoc).value,
-      (target in unidoc).value, configuration.value, streams.value),
+      (target in unidoc).value, configuration.value, streams.value, (sourcePositionMappers in unidoc).value),
     compilers in unidoc := (compilers in sc).value,
     sources in unidoc := (unidocAllSources in unidoc).value.flatten,
     scalacOptions in unidoc := (scalacOptions in (sc, doc)).value,


### PR DESCRIPTION
There are now separate `Unidoc` objects for 0.13 and 1.0. I tried to adapt the `docTaskSettings` [bits from 1.0](https://github.com/sbt/sbt/blob/1.0.0/main/src/main/scala/sbt/Defaults.scala#L1262).

Should take care of #37.