### PR TITLE
Updated to latest genjavadoc, sbt and scala versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,12 @@ script:
 matrix:
   include:
   - env: SBT_VERSION="0.13.18"
-    scala: 2.10.7
+    scala:
+      - 2.10.7
 
-  - env: SBT_VERSION="1.2.7"
-    scala: 2.12.8
+  - env: SBT_VERSION="1.2.8"
+    scala:
+      - 2.12.8
 
 cache:
   directories:

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ lazy val root = (project in file(".")).
   settings(commonSettings: _*).
   settings(
     sbtPlugin := true,
-    crossSbtVersions := Vector("0.13.18", "1.2.7"),
+    crossSbtVersions := Vector("0.13.18", "1.2.8"),
     name := "sbt-unidoc",
     description := "sbt plugin to create a unified API document across projects",
     licenses := Seq("Apache License v2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html")),

--- a/src/main/scala/sbtunidoc/GenJavadocPlugin.scala
+++ b/src/main/scala/sbtunidoc/GenJavadocPlugin.scala
@@ -10,7 +10,7 @@ object GenJavadocPlugin extends AutoPlugin {
   }
   import autoImport._
 
-  override def globalSettings = unidocGenjavadocVersion := "0.13"
+  override def globalSettings = unidocGenjavadocVersion := "0.15"
 
   override def requires = JvmPlugin
 


### PR DESCRIPTION
Scala 2.13.1 support has been added since the latest release of genjavadoc (0.15), making this lib available for use in Scala 2.13.
Also, while I was at it anyways, I updated to the latest sbt patch version (1.2.8) and updated the travis build.