### PR TITLE
JDK17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,17 @@ jobs:
           - scala-version: '2.12.15'
             sbt-version: '1.5.5'
             java-version: 11
+          - scala-version: '2.12.15'
+            sbt-version: '1.5.5'
+            java-version: 17
+
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v2
       - name: Setup java
-        uses: actions/setup-java@v2.3.0
+        uses: actions/setup-java@v2.3.1
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: ${{ matrix.java-version }}
       - name: Test
         env:

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ lazy val root = (project in file("."))
   .enablePlugins(SbtPlugin)
   .settings(
     name := "sbt-unidoc",
-    scriptedLaunchOpts ++= Seq("-Xmx1024M", "-XX:MaxPermSize=256M", "-Dplugin.version=" + version.value),
+    scriptedLaunchOpts ++= Seq("-Xmx1024M", "-Dplugin.version=" + version.value),
     scriptedBufferLog := false,
     // sbt-unidoc requires sbt 1.5.0 and up
     pluginCrossBuild / sbtVersion := "1.5.0",

--- a/src/sbt-test/unidoc/java-unidoc/build.sbt
+++ b/src/sbt-test/unidoc/java-unidoc/build.sbt
@@ -23,7 +23,9 @@ lazy val root = project.in(file(".")).settings(
 )
 
 TaskKey[Unit]("check") := {
-  if (scala.util.Properties.isJavaAtLeast("11")) {
+  if (scala.util.Properties.isJavaAtLeast("17")) {
+    assert(file("target/javaunidoc/allclasses-index.html").isFile)
+  } else if (scala.util.Properties.isJavaAtLeast("11")) {
     assert(file("target/javaunidoc/allclasses.html").isFile)
   } else {
     assert(file("target/javaunidoc/allclasses-frame.html").isFile)


### PR DESCRIPTION
 - removed MaxPermSize param from scriptedLaunchOpts
   MaxPermSize is deprecated at Java8 and removed at Java17
 - changed java-unidoc test
   The generated file name differs depending on the javadoc version
 - changed the JDK distribution used for GitHub actions to Temurin